### PR TITLE
Improve Devcontainers and Environments

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,9 @@
 FROM mcr.microsoft.com/devcontainers/anaconda:0-3
 
 COPY environment.yml* .devcontainer/noop.txt /tmp/conda-tmp/
-RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then umask 0002 && /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml; fi \
+# https://www.sckaiser.com/blog/2023/01/30/conda-codespaces.html
+# make a new environment instead of creating one
+RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then umask 0002 && /opt/conda/bin/conda env create -n env -f /tmp/conda-tmp/environment.yml; fi \
     && rm -rf /tmp/conda-tmp
 
 # [Optional] Uncomment this section to install additional OS packages.

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/devcontainers/anaconda:0-3
 
 COPY environment.yml* .devcontainer/noop.txt /tmp/conda-tmp/
 # https://www.sckaiser.com/blog/2023/01/30/conda-codespaces.html
-# make a new environment instead of creating one
+# make a new environment instead of merging into base
 RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then umask 0002 && /opt/conda/bin/conda env create -n env -f /tmp/conda-tmp/environment.yml; fi \
     && rm -rf /tmp/conda-tmp
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,6 +15,12 @@
 	},
 	"customizations": {
 		"vscode": {
+			// set default python interpreter to our custom conda env
+			"settings": {
+				"python.defaultInterpreterPath": "/opt/conda/envs/env",
+				"python.terminal.activateEnvironment": true,
+				"python.condaPath": "/opt/conda/envs/env/bin/python"
+			},
 			"extensions": [
 				"ms-toolsai.jupyter",
 				"ms-azuretools.vscode-docker",
@@ -26,7 +32,9 @@
 				"ms-vscode.azure-account"
 			]
 		}
-	}
+	},
+	// My custom post create command initializes conda and does some other stuff
+	"postCreateCommand": "./.devcontainer/postcreate.sh"
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,9 @@
 				"python.defaultInterpreterPath": "/opt/conda/envs/env",
 				// the `conda activate env` I add to `~/.bashrc` in `postcreate.sh` works better
 				// than the activateEnvironment here.
-				"python.terminal.activateEnvironment": false
+				"python.terminal.activateEnvironment": false,
+				// default pylint won't be able to resolve dependencies in our custom conda environment
+				"python.linting.pylintPath": "/opt/conda/envs/env/bin/pylint"
 			},
 			"extensions": [
 				"ms-toolsai.jupyter",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,8 +18,9 @@
 			// set default python interpreter to our custom conda env
 			"settings": {
 				"python.defaultInterpreterPath": "/opt/conda/envs/env",
-				"python.terminal.activateEnvironment": true,
-				"python.condaPath": "/opt/conda/envs/env/bin/python"
+				// the `conda activate env` I add to `~/.bashrc` in `postcreate.sh` works better
+				// than the activateEnvironment here.
+				"python.terminal.activateEnvironment": false
 			},
 			"extensions": [
 				"ms-toolsai.jupyter",

--- a/.devcontainer/postcreate.sh
+++ b/.devcontainer/postcreate.sh
@@ -1,0 +1,19 @@
+# POST CREATE
+# Reference (very good blog!!): https://www.sckaiser.com/blog/2023/01/30/conda-codespaces.html
+
+
+# initialize conda in the container
+# somehow this always fails with a `TypeError: memoryview: a bytes-like object is required, not 'str'`
+# but conda is still inittialized. I just ignore the error with `|| true` lol
+# the "yes N" is to skip the interactivity of conda init when it fails
+yes N | conda init || true 
+
+# after conda initializes, we can activate the environment
+# this makes sure we have our custom env activated in our new terminals
+echo 'conda activate env' >> ~/.bashrc
+
+# bash colours: https://stackoverflow.com/a/5947802
+# Tell users that the conda error is a-ok!!
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+printf "\nIf there is a conda error, ${GREEN}DO NOT WORRY!! EVERYTHING IS OKAY!!${NC}\nSee .devcontainer/postcreate.sh for more info.\n"

--- a/.devcontainer/postcreate.sh
+++ b/.devcontainer/postcreate.sh
@@ -10,6 +10,7 @@ yes N | conda init || true
 
 # after conda initializes, we can activate the environment
 # this makes sure we have our custom env activated in our new terminals
+# I find this is a better UX than vscode's "python.terminal.activateEnvironment" setting
 echo 'conda activate env' >> ~/.bashrc
 
 # bash colours: https://stackoverflow.com/a/5947802

--- a/.github/workflows/environment.yml
+++ b/.github/workflows/environment.yml
@@ -11,6 +11,11 @@ on:
       - .github/workflows/environment.yml # this file
       - environment.yml # actual conda environment file
       - azure/env/update.py # script to update environment
+  pull_request:
+    paths:
+      - .github/workflows/environment.yml # this file
+      - environment.yml # actual conda environment file
+      - azure/env/update.py # script to update environment
 
 jobs:
   # this runs train-evaluate-register stuff on the Azure compute instances.
@@ -66,7 +71,9 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
 
       # version automatically updates, even if environment.yml doesn't change
+      # we only actually deploy if the workflow is triggered by a push to main
       - name: Run Deploy
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           PYTHONPATH="lib" python azure/env/update.py
         env:

--- a/.github/workflows/environment.yml
+++ b/.github/workflows/environment.yml
@@ -1,5 +1,7 @@
-name: Upload New Environment
+name: Environment Changed
 
+# Update environment (push changes to Azure if it's a push to main)
+# Then run Pipeline to see if everything is working with the new environment
 
 on: 
   workflow_dispatch:

--- a/.github/workflows/environment.yml
+++ b/.github/workflows/environment.yml
@@ -71,9 +71,10 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
 
       # version automatically updates, even if environment.yml doesn't change
-      # we only actually deploy if the workflow is triggered by a push to main
       - name: Run Deploy
-        if: steps.cache.outputs.cache-hit != 'true'
+        # run only if it's a push to main (and not a PR)
+        # https://stackoverflow.com/a/66206183
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         run: |
           PYTHONPATH="lib" python azure/env/update.py
         env:

--- a/environment.yml
+++ b/environment.yml
@@ -14,5 +14,6 @@ dependencies:
       - azure-ai-ml
       - mlflow[extras]
       - inference-schema
+      - pylint==2.17.4
       - azureml-inference-server-http # needed to run local endpoint
       - azure-cli # used in Github Actions

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ name: base
 channels:
   - defaults
 dependencies:
-  - python=3.9.13
+  - python=3.11.3
   - pip
   - pip:
       - numpy
@@ -14,4 +14,4 @@ dependencies:
       - mlflow[extras]
       - inference-schema
       - azureml-inference-server-http # needed to run local endpoint
-      - azure-cli
+      - azure-cli # delete?

--- a/environment.yml
+++ b/environment.yml
@@ -9,9 +9,10 @@ dependencies:
   - pip
   - pip:
       - numpy
+      - scikit-learn==1.2.2
       - azureml-mlflow
       - azure-ai-ml
       - mlflow[extras]
       - inference-schema
       - azureml-inference-server-http # needed to run local endpoint
-      - azure-cli # delete?
+      - azure-cli # used in Github Actions

--- a/environment.yml
+++ b/environment.yml
@@ -5,15 +5,15 @@ name: base
 channels:
   - defaults
 dependencies:
-  - python=3.11.3
+  - python=3.10
   - pip
   - pip:
       - numpy
       - scikit-learn==1.2.2
       - azureml-mlflow
-      - azure-ai-ml
-      - mlflow[extras]
-      - inference-schema
-      - pylint==2.17.4 # for development
-      - azureml-inference-server-http # needed to run local endpoint
+      - azure-ai-ml # azure/
+      - mlflow[extras] # azure/train
+      - inference-schema # azure/deploy/score.py
+      - azureml-inference-server-http # needed to run local endpoint i guess?
+      - pylint # for development
       - azure-cli # used in Github Actions

--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,6 @@ dependencies:
       - azure-ai-ml
       - mlflow[extras]
       - inference-schema
-      - pylint==2.17.4
+      - pylint==2.17.4 # for development
       - azureml-inference-server-http # needed to run local endpoint
       - azure-cli # used in Github Actions

--- a/lib/deploy_helpers.py
+++ b/lib/deploy_helpers.py
@@ -35,7 +35,8 @@ def get_envs() -> tuple[str, str, str]:
     def get_single_env(env: str) -> str:
         e_val = os.environ.get(env)
         if e_val is None:
-            raise Exception(f"Environment variable {env} is not set.")
+            print(f'Environment variable {env} is not set! Exiting')
+            sys.exit(1)
         return e_val
 
     return (
@@ -116,7 +117,7 @@ def ml_environment(mlclient: MLClient, local: bool) -> Environment:
     env = Environment(
         name='local',
         conda_file='environment.yml',
-        image='mcr.microsoft.com/azureml/sklearn-0.24.1-ubuntu18.04-py37-cpu-inference:latest'
+        image='mcr.microsoft.com/azureml/minimal-ubuntu20.04-py38-cpu-inference:latest'
     )
     print(f'Local environment made:\n{env}')
 


### PR DESCRIPTION
- Fixed python version (3.10.11)
- Fixed scikit-learn version (1.2.2)
- Use new conda environment in devcontainer instead of installing it into base - much faster builds now!
- Make pylint work in devcontainer (seemingly for the fifth time)
- Use `minimal-ubuntu20.04-py38-cpu-inference` base image instead of `sklearn-0.24.1-ubuntu18.04-py37-cpu-inference` for training and deployment